### PR TITLE
added content type for about page

### DIFF
--- a/backend/api/about-head/config/routes.json
+++ b/backend/api/about-head/config/routes.json
@@ -1,0 +1,28 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/about-head",
+      "handler": "about-head.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/about-head",
+      "handler": "about-head.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/about-head",
+      "handler": "about-head.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/about-head/controllers/about-head.js
+++ b/backend/api/about-head/controllers/about-head.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/about-head/models/about-head.js
+++ b/backend/api/about-head/models/about-head.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/about-head/models/about-head.settings.json
+++ b/backend/api/about-head/models/about-head.settings.json
@@ -1,0 +1,23 @@
+{
+  "kind": "singleType",
+  "collectionName": "about_heads",
+  "info": {
+    "name": "about_us"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "about_head": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.mini-card"
+    },
+    "about_description": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.mini-card"
+    }
+  }
+}

--- a/backend/api/about-head/services/about-head.js
+++ b/backend/api/about-head/services/about-head.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/backend/api/organization-founders/config/routes.json
+++ b/backend/api/organization-founders/config/routes.json
@@ -1,0 +1,28 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/organization-founders",
+      "handler": "organization-founders.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/organization-founders",
+      "handler": "organization-founders.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/organization-founders",
+      "handler": "organization-founders.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/organization-founders/controllers/organization-founders.js
+++ b/backend/api/organization-founders/controllers/organization-founders.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/organization-founders/models/organization-founders.js
+++ b/backend/api/organization-founders/models/organization-founders.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/organization-founders/models/organization-founders.settings.json
+++ b/backend/api/organization-founders/models/organization-founders.settings.json
@@ -1,0 +1,23 @@
+{
+  "kind": "singleType",
+  "collectionName": "organization_founders",
+  "info": {
+    "name": "organization_founders"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "default": "title",
+      "required": true
+    },
+    "member": {
+      "type": "component",
+      "repeatable": true,
+      "component": "general.cards"
+    }
+  }
+}

--- a/backend/api/organization-founders/services/organization-founders.js
+++ b/backend/api/organization-founders/services/organization-founders.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/backend/components/general/mini-card.json
+++ b/backend/components/general/mini-card.json
@@ -1,0 +1,27 @@
+{
+  "collectionName": "components_general_mini_cards",
+  "info": {
+    "name": "mini_card",
+    "icon": "info"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "sub_title": {
+      "type": "string"
+    },
+    "image": {
+      "model": "file",
+      "via": "related",
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos"
+      ],
+      "plugin": "upload",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
## Description

- added content type for about page `banner` (top section) and the below section that describes the organization using siblge type named `About_us`
- added content type for the founder of the initiative using single type named `Organization_founders`