### PR TITLE
added content type for projects

### DIFF
--- a/backend/api/batch/models/batch.settings.json
+++ b/backend/api/batch/models/batch.settings.json
@@ -34,6 +34,10 @@
       "type": "uid",
       "targetField": "title",
       "required": false
+    },
+    "projects": {
+      "via": "batches",
+      "collection": "project"
     }
   }
 }

--- a/backend/api/project/config/routes.json
+++ b/backend/api/project/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/projects",
+      "handler": "project.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/projects/count",
+      "handler": "project.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/projects/:id",
+      "handler": "project.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/projects",
+      "handler": "project.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/projects/:id",
+      "handler": "project.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/projects/:id",
+      "handler": "project.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/project/controllers/project.js
+++ b/backend/api/project/controllers/project.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/project/models/project.js
+++ b/backend/api/project/models/project.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/project/models/project.settings.json
+++ b/backend/api/project/models/project.settings.json
@@ -9,11 +9,6 @@
     "timestamps": true
   },
   "attributes": {
-    "project_nav_page": {
-      "type": "component",
-      "repeatable": false,
-      "component": "general.link"
-    },
     "project_slug": {
       "type": "uid",
       "targetField": "project_name"
@@ -23,25 +18,10 @@
       "via": "projects",
       "dominant": true
     },
-    "project_repo": {
-      "type": "component",
-      "repeatable": false,
-      "component": "general.link"
-    },
-    "project_link_production": {
-      "type": "component",
-      "repeatable": false,
-      "component": "general.link"
-    },
     "batches_description": {
       "type": "component",
       "repeatable": false,
       "component": "general.mini-card"
-    },
-    "project_head": {
-      "type": "component",
-      "repeatable": false,
-      "component": "general.cards"
     },
     "join_next_project": {
       "type": "component",
@@ -55,6 +35,11 @@
     },
     "project_name": {
       "type": "string"
+    },
+    "project_head": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.card-with-link"
     }
   }
 }

--- a/backend/api/project/models/project.settings.json
+++ b/backend/api/project/models/project.settings.json
@@ -1,0 +1,60 @@
+{
+  "kind": "collectionType",
+  "collectionName": "projects",
+  "info": {
+    "name": "project"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "project_nav_page": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.link"
+    },
+    "project_slug": {
+      "type": "uid",
+      "targetField": "project_name"
+    },
+    "batches": {
+      "collection": "batch",
+      "via": "projects",
+      "dominant": true
+    },
+    "project_repo": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.link"
+    },
+    "project_link_production": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.link"
+    },
+    "batches_description": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.mini-card"
+    },
+    "project_head": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.cards"
+    },
+    "join_next_project": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.dashed-card"
+    },
+    "project_overview": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.card-with-link"
+    },
+    "project_name": {
+      "type": "string"
+    }
+  }
+}

--- a/backend/api/project/models/project.settings.json
+++ b/backend/api/project/models/project.settings.json
@@ -11,7 +11,8 @@
   "attributes": {
     "project_slug": {
       "type": "uid",
-      "targetField": "project_name"
+      "targetField": "project_name",
+      "required": true
     },
     "batches": {
       "collection": "batch",
@@ -40,6 +41,10 @@
       "type": "component",
       "repeatable": false,
       "component": "general.card-with-link"
+    },
+    "nav_to_project_page_text": {
+      "type": "string",
+      "required": true
     }
   }
 }

--- a/backend/api/project/services/project.js
+++ b/backend/api/project/services/project.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/backend/api/projects-info/config/routes.json
+++ b/backend/api/projects-info/config/routes.json
@@ -1,0 +1,28 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/projects-info",
+      "handler": "projects-info.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/projects-info",
+      "handler": "projects-info.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/projects-info",
+      "handler": "projects-info.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/projects-info/controllers/projects-info.js
+++ b/backend/api/projects-info/controllers/projects-info.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/projects-info/models/projects-info.js
+++ b/backend/api/projects-info/models/projects-info.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/projects-info/models/projects-info.settings.json
+++ b/backend/api/projects-info/models/projects-info.settings.json
@@ -1,0 +1,18 @@
+{
+  "kind": "singleType",
+  "collectionName": "projects_infos",
+  "info": {
+    "name": "projects_info"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "projects_brief": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.mini-card"
+    }
+  }
+}

--- a/backend/api/projects-info/services/projects-info.js
+++ b/backend/api/projects-info/services/projects-info.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/backend/components/general/card-with-link.json
+++ b/backend/components/general/card-with-link.json
@@ -1,0 +1,24 @@
+{
+  "collectionName": "components_general_card_with_links",
+  "info": {
+    "name": "card_with_link",
+    "icon": "ambulance"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "desciption": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "link": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.link"
+    }
+  }
+}

--- a/backend/components/general/card-with-link.json
+++ b/backend/components/general/card-with-link.json
@@ -19,6 +19,17 @@
       "type": "component",
       "repeatable": false,
       "component": "general.link"
+    },
+    "image": {
+      "model": "file",
+      "via": "related",
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos"
+      ],
+      "plugin": "upload",
+      "required": false
     }
   }
 }


### PR DESCRIPTION
### Description

- created content type for the projects section on the home page as below


| field name   | field type |
| ------------- | ------------- |
|   title | Text |
| sub_title | Text  |
| image | Media |

- The relation between projects and batches is **_many to many_**. so each project can have many batches and the batch can have many projects
- to get the description of the **_projects section_** on the home page use this endpoint `/projects-info`
- you can get all data related to project page  through this endpoint `/projects` 
- select the data required for the **first** section on the page under the field named `project_head`.
- select the data required for **batches** sections can be selected from the following fields
 `batches_description`,`batches`,`batches`,`join_next_project`.
-  select the data required for **overview** section under the field `project_overview`.

  


