### PR TITLE
change field name to match the name used inside the component

### DIFF
--- a/backend/components/general/card-with-link.json
+++ b/backend/components/general/card-with-link.json
@@ -20,7 +20,7 @@
       "repeatable": false,
       "component": "general.link"
     },
-    "image": {
+    "header_image": {
       "model": "file",
       "via": "related",
       "allowedTypes": [

--- a/backend/components/general/card-with-link.json
+++ b/backend/components/general/card-with-link.json
@@ -9,7 +9,7 @@
     "title": {
       "type": "string"
     },
-    "desciption": {
+    "description": {
       "type": "string"
     },
     "summary": {


### PR DESCRIPTION
### Description
- change the name of this field `image` in the content-type `card-with-link` to `header_image` to match the name used by  the component `shared/SectionHeader`

- fix typo in `project` content type from ~~desciption~~ to  `description`