### PR TITLE
added content type for projects description in patch page

### DIFF
--- a/backend/api/batch-projects-description/config/routes.json
+++ b/backend/api/batch-projects-description/config/routes.json
@@ -1,0 +1,28 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/batch-projects-description",
+      "handler": "batch-projects-description.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/batch-projects-description",
+      "handler": "batch-projects-description.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/batch-projects-description",
+      "handler": "batch-projects-description.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/backend/api/batch-projects-description/controllers/batch-projects-description.js
+++ b/backend/api/batch-projects-description/controllers/batch-projects-description.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/backend/api/batch-projects-description/models/batch-projects-description.js
+++ b/backend/api/batch-projects-description/models/batch-projects-description.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/backend/api/batch-projects-description/models/batch-projects-description.settings.json
+++ b/backend/api/batch-projects-description/models/batch-projects-description.settings.json
@@ -1,0 +1,20 @@
+{
+  "kind": "singleType",
+  "collectionName": "batch_projects_descriptions",
+  "info": {
+    "name": "batch_projects_description"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "text"
+    }
+  }
+}

--- a/backend/api/batch-projects-description/services/batch-projects-description.js
+++ b/backend/api/batch-projects-description/services/batch-projects-description.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};


### PR DESCRIPTION
### Description

- added content type for the projects description named  `Batch_projects_description`
- it will be consumed in the batch page