### PR TITLE
upgrade minio provider to fix svg bug

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "strapi-plugin-email": "3.0.6",
     "strapi-plugin-upload": "3.0.6",
     "strapi-plugin-users-permissions": "3.0.6",
-    "strapi-provider-upload-m3-minio": "^1.0.1",
+    "strapi-provider-upload-m3-minio": "^1.0.2",
     "strapi-utils": "3.0.6"
   },
   "author": {

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -8841,10 +8841,10 @@ strapi-provider-upload-local@3.0.6:
   resolved "https://registry.yarnpkg.com/strapi-provider-upload-local/-/strapi-provider-upload-local-3.0.6.tgz#cce78d0ed14886c22d25d2a649dccf561f58d2d7"
   integrity sha512-ol4BVh/rGaoklUu4Xzwe0tixQ/U1jKWjjZ8Am3wgzA2zJ0+RlhxgLNAgVebUbkwBrA6SNkLdMGx04pkD0zHW+w==
 
-strapi-provider-upload-m3-minio@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/strapi-provider-upload-m3-minio/-/strapi-provider-upload-m3-minio-1.0.1.tgz#2f399b9bbfd89507d0093507d1462d1f5614e701"
-  integrity sha512-V3DQNkJNGMYR+VU0Af5Diw7ZF3G8rNnzzmv04wvnsdebVaHa+npJi9kNfujGudeVCP+iTePwBa81P2O/gOo48g==
+strapi-provider-upload-m3-minio@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/strapi-provider-upload-m3-minio/-/strapi-provider-upload-m3-minio-1.0.2.tgz#70520b528fe361d4203fdcbf14def7e650cfd44f"
+  integrity sha512-tPVWwe+70TRBRVqFLf/M5w6So2KYe03OcTX1V4zwxR+5tvRIZOqkE3zydf3nEfS2mHsCUduGljaHPeCYMnPWYQ==
   dependencies:
     minio "^7.0.1"
 


### PR DESCRIPTION
as a continuation of the svg upload issue, this PR is to use the fixed version of our upload plugin

please refer to [this PR](https://github.com/m3ntorship/strapi-provider-upload-m3-minio/pull/1) for the changes required to fix the bug.
