### PR TITLE
remove align-self css property

### DIFF
--- a/frontend/components/resources/index.jsx
+++ b/frontend/components/resources/index.jsx
@@ -96,7 +96,7 @@ export default function resources({ title, resourcesCards }) {
           </AnimatePresence>
         </div>
 
-        <p className="text-c600 text-xxs leading-6 ml-10 self-end flex-none order-1">
+        <p className="text-c600 text-xxs leading-6 ml-10  flex-none order-1">
           {description}
         </p>
       </div>


### PR DESCRIPTION
#### Description
- remove the unnecessary class name `self-end` which aligns the text inside `p` tag to the right.